### PR TITLE
feat: 오늘의 미션을 성공했다고 클릭 했을 때 update하면서 지금까지 성공한 미션개수 보여주기, fix: 이슈 피드백에 따라 테스트 수정

### DIFF
--- a/src/docs/asciidoc/api/missionOutcome/missionOutcome.adoc
+++ b/src/docs/asciidoc/api/missionOutcome/missionOutcome.adoc
@@ -24,15 +24,3 @@ include::{snippets}/missionOutcome-update/request-fields.adoc[]
 
 include::{snippets}/missionOutcome-update/http-response.adoc[]
 include::{snippets}/missionOutcome-update/response-fields.adoc[]
-
-=== 미션결과 조회
-
-==== HTTP Request
-
-include::{snippets}/missionOutcome-get/http-request.adoc[]
-include::{snippets}/missionOutcome-get/query-parameters.adoc[]
-
-==== HTTP Response
-
-include::{snippets}/missionOutcome-get/http-response.adoc[]
-include::{snippets}/missionOutcome-get/response-fields.adoc[]

--- a/src/main/java/com/luckkids/api/controller/mission/MissionController.java
+++ b/src/main/java/com/luckkids/api/controller/mission/MissionController.java
@@ -6,7 +6,6 @@ import com.luckkids.api.controller.mission.request.MissionUpdateRequest;
 import com.luckkids.api.service.mission.MissionReadService;
 import com.luckkids.api.service.mission.MissionService;
 import com.luckkids.api.service.mission.response.MissionResponse;
-import com.luckkids.api.service.security.SecurityService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,13 +21,11 @@ public class MissionController {
 
     private final MissionService missionService;
     private final MissionReadService missionReadService;
-    private final SecurityService securityService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/api/v1/missions/new")
     public ApiResponse<MissionResponse> createMission(@Valid @RequestBody MissionCreateRequest request) {
-        int userId = securityService.getCurrentUserInfo().getUserId();
-        return ApiResponse.created(missionService.createMission(request.toServiceRequest(), userId));
+        return ApiResponse.created(missionService.createMission(request.toServiceRequest()));
     }
 
     @PatchMapping("/api/v1/missions/{missionId}")
@@ -39,8 +36,7 @@ public class MissionController {
 
     @GetMapping("/api/v1/missions")
     public ApiResponse<List<MissionResponse>> getMission() {
-        int userId = securityService.getCurrentUserInfo().getUserId();
-        return ApiResponse.ok(missionReadService.getMission(userId));
+        return ApiResponse.ok(missionReadService.getMission());
     }
 
     @DeleteMapping("/api/v1/missions/{missionId}")

--- a/src/main/java/com/luckkids/api/controller/missionOutcome/MissionOutcomeController.java
+++ b/src/main/java/com/luckkids/api/controller/missionOutcome/MissionOutcomeController.java
@@ -5,7 +5,6 @@ import com.luckkids.api.controller.missionOutcome.request.MissionOutcomeUpdateRe
 import com.luckkids.api.service.missionOutcome.MissionOutcomeReadService;
 import com.luckkids.api.service.missionOutcome.MissionOutcomeService;
 import com.luckkids.api.service.missionOutcome.response.MissionOutcomeResponse;
-import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.domain.missionOutcome.MissionStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,17 +21,16 @@ public class MissionOutcomeController {
 
     private final MissionOutcomeService missionOutcomeService;
     private final MissionOutcomeReadService missionOutcomeReadService;
-    private final SecurityService securityService;
 
     @PatchMapping("/api/v1/missionOutcomes/{missionOutcomeId}")
-    public ApiResponse<Long> updateMissionOutcome(@PathVariable Long missionOutcomeId,
-                                                  @Valid @RequestBody MissionOutcomeUpdateRequest request) {
+    public ApiResponse<Integer> updateMissionOutcome(@PathVariable Long missionOutcomeId,
+                                                     @Valid @RequestBody MissionOutcomeUpdateRequest request) {
         return ApiResponse.ok(missionOutcomeService.updateMissionOutcome(missionOutcomeId, request.getMissionStatus()));
     }
 
     @GetMapping("/api/v1/missionOutcomes")
     public ApiResponse<List<MissionOutcomeResponse>> getMissionDetailListForStatus(@RequestParam(required = false) MissionStatus missionStatus) {
-        int userId = securityService.getCurrentUserInfo().getUserId();
-        return ApiResponse.ok(missionOutcomeReadService.getMissionDetailListForStatus(ofNullable(missionStatus), userId, now()));
+
+        return ApiResponse.ok(missionOutcomeReadService.getMissionDetailListForStatus(ofNullable(missionStatus), now()));
     }
 }

--- a/src/main/java/com/luckkids/api/service/mission/MissionReadService.java
+++ b/src/main/java/com/luckkids/api/service/mission/MissionReadService.java
@@ -1,6 +1,7 @@
 package com.luckkids.api.service.mission;
 
 import com.luckkids.api.service.mission.response.MissionResponse;
+import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.domain.misson.Mission;
 import com.luckkids.domain.misson.MissionRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,12 +18,15 @@ public class MissionReadService {
 
     private final MissionRepository missionRepository;
 
+    private final SecurityService securityService;
+
     public Mission findByOne(int id) {
         return missionRepository.findByIdAndDeletedDateIsNull(id)
             .orElseThrow(() -> new IllegalArgumentException("해당 미션은 없습니다. id = " + id));
     }
 
-    public List<MissionResponse> getMission(int userId) {
+    public List<MissionResponse> getMission() {
+        int userId = securityService.getCurrentUserInfo().getUserId();
         List<Mission> missions = missionRepository.findAllByUserIdAndDeletedDateIsNull(userId);
 
         return missions.stream().map(MissionResponse::of).collect(Collectors.toList());

--- a/src/main/java/com/luckkids/api/service/mission/MissionService.java
+++ b/src/main/java/com/luckkids/api/service/mission/MissionService.java
@@ -5,6 +5,7 @@ import com.luckkids.api.event.missionOutcome.MissionOutcomeDeleteEvent;
 import com.luckkids.api.service.mission.request.MissionCreateServiceRequest;
 import com.luckkids.api.service.mission.request.MissionUpdateServiceRequest;
 import com.luckkids.api.service.mission.response.MissionResponse;
+import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.api.service.user.UserReadService;
 import com.luckkids.domain.misson.Mission;
 import com.luckkids.domain.misson.MissionRepository;
@@ -25,10 +26,12 @@ public class MissionService {
 
     private final MissionReadService missionReadService;
     private final UserReadService userReadService;
+    private final SecurityService securityService;
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public MissionResponse createMission(MissionCreateServiceRequest request, int userId) {
+    public MissionResponse createMission(MissionCreateServiceRequest request) {
+        int userId = securityService.getCurrentUserInfo().getUserId();
         User user = userReadService.findByOne(userId);
 
         Mission mission = request.toEntity(user);

--- a/src/main/java/com/luckkids/api/service/missionOutcome/MissionOutcomeReadService.java
+++ b/src/main/java/com/luckkids/api/service/missionOutcome/MissionOutcomeReadService.java
@@ -1,6 +1,7 @@
 package com.luckkids.api.service.missionOutcome;
 
 import com.luckkids.api.service.missionOutcome.response.MissionOutcomeResponse;
+import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.domain.missionOutcome.MissionOutcome;
 import com.luckkids.domain.missionOutcome.MissionOutcomeQueryRepository;
 import com.luckkids.domain.missionOutcome.MissionOutcomeRepository;
@@ -21,16 +22,24 @@ public class MissionOutcomeReadService {
 
     private final MissionOutcomeRepository missionOutcomeRepository;
     private final MissionOutcomeQueryRepository missionOutcomeQueryRepository;
+    
+    private final SecurityService securityService;
 
     public MissionOutcome findByOne(Long id) {
         return missionOutcomeRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("해당 미션결과는 없습니다. id = " + id));
     }
 
-    public List<MissionOutcomeResponse> getMissionDetailListForStatus(Optional<MissionStatus> missionStatus, int userId, LocalDate missionDate) {
+    public List<MissionOutcomeResponse> getMissionDetailListForStatus(Optional<MissionStatus> missionStatus, LocalDate missionDate) {
+        int userId = securityService.getCurrentUserInfo().getUserId();
         return missionOutcomeQueryRepository.findMissionDetailsByStatus(missionStatus, userId, missionDate)
             .stream()
             .map(MissionOutcomeDetailDto::toMissionOutcomeResponse)
             .toList();
+    }
+
+    public int countUserSuccessfulMissions() {
+        int userId = securityService.getCurrentUserInfo().getUserId();
+        return missionOutcomeRepository.countSuccessfulMissionsByUserId(userId);
     }
 }

--- a/src/main/java/com/luckkids/api/service/missionOutcome/MissionOutcomeService.java
+++ b/src/main/java/com/luckkids/api/service/missionOutcome/MissionOutcomeService.java
@@ -24,11 +24,11 @@ public class MissionOutcomeService {
         missionOutcomeRepository.save(missionOutcome);
     }
 
-    public Long updateMissionOutcome(Long missionOutcomeId, MissionStatus missionStatus) {
+    public int updateMissionOutcome(Long missionOutcomeId, MissionStatus missionStatus) {
         MissionOutcome missionOutcome = missionOutcomeReadService.findByOne(missionOutcomeId);
         missionOutcome.updateMissionStatus(missionStatus);
 
-        return missionOutcomeId;
+        return missionOutcomeReadService.countUserSuccessfulMissions();
     }
 
     public void deleteMissionOutcome(int missionId, LocalDate missionDate) {

--- a/src/main/java/com/luckkids/domain/missionOutcome/MissionOutcomeRepository.java
+++ b/src/main/java/com/luckkids/domain/missionOutcome/MissionOutcomeRepository.java
@@ -1,6 +1,7 @@
 package com.luckkids.domain.missionOutcome;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -9,4 +10,10 @@ import java.time.LocalDate;
 public interface MissionOutcomeRepository extends JpaRepository<MissionOutcome, Long> {
 
     void deleteAllByMissionIdAndMissionDate(int mission_id, LocalDate missionDate);
+
+    @Query("SELECT COUNT(mo) " +
+        "FROM MissionOutcome mo " +
+        "WHERE mo.missionStatus = 'SUCCEED' " +
+        "AND mo.mission.id IN (SELECT m.id FROM Mission m WHERE m.user.id = :userId)")
+    int countSuccessfulMissionsByUserId(int userId);
 }

--- a/src/test/java/com/luckkids/IntegrationTestSupport.java
+++ b/src/test/java/com/luckkids/IntegrationTestSupport.java
@@ -1,9 +1,14 @@
 package com.luckkids;
 
+import com.luckkids.api.service.security.SecurityService;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationTestSupport {
+
+    @MockBean
+    protected SecurityService securityService;
 }

--- a/src/test/java/com/luckkids/api/controller/mission/MissionControllerTest.java
+++ b/src/test/java/com/luckkids/api/controller/mission/MissionControllerTest.java
@@ -3,7 +3,6 @@ package com.luckkids.api.controller.mission;
 import com.luckkids.ControllerTestSupport;
 import com.luckkids.api.controller.mission.request.MissionCreateRequest;
 import com.luckkids.api.controller.mission.request.MissionUpdateRequest;
-import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -11,7 +10,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import java.time.LocalTime;
 
 import static com.luckkids.domain.misson.AlertStatus.CHECKED;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -31,9 +29,6 @@ class MissionControllerTest extends ControllerTestSupport {
             .alertStatus(CHECKED)
             .alertTime(LocalTime.of(18, 30))
             .build();
-
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
 
         // when // then
         mockMvc.perform(
@@ -154,8 +149,6 @@ class MissionControllerTest extends ControllerTestSupport {
     @WithMockUser(roles = "USER")
     void getMission() throws Exception {
         //given
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
 
         // when // then
         mockMvc.perform(
@@ -167,13 +160,6 @@ class MissionControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.httpStatus").value("OK"))
             .andExpect(jsonPath("$.message").value("OK"));
 
-    }
-
-    private UserInfo createUserInfo() {
-        return UserInfo.builder()
-            .userId(1)
-            .email("")
-            .build();
     }
 
     @DisplayName("등록되어있는 미션을 삭제한다.")

--- a/src/test/java/com/luckkids/api/controller/missionOutcome/MissionOutcomeControllerTest.java
+++ b/src/test/java/com/luckkids/api/controller/missionOutcome/MissionOutcomeControllerTest.java
@@ -2,13 +2,11 @@ package com.luckkids.api.controller.missionOutcome;
 
 import com.luckkids.ControllerTestSupport;
 import com.luckkids.api.controller.missionOutcome.request.MissionOutcomeUpdateRequest;
-import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import static com.luckkids.domain.missionOutcome.MissionStatus.SUCCEED;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -70,8 +68,6 @@ class MissionOutcomeControllerTest extends ControllerTestSupport {
     @WithMockUser(roles = "USER")
     void getMissionDetailListForStatus() throws Exception {
         // given
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
 
         // when // then
         mockMvc.perform(
@@ -83,12 +79,4 @@ class MissionOutcomeControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.httpStatus").value("OK"))
             .andExpect(jsonPath("$.message").value("OK"));
     }
-
-    private UserInfo createUserInfo() {
-        return UserInfo.builder()
-            .userId(1)
-            .email("")
-            .build();
-    }
-
 }

--- a/src/test/java/com/luckkids/api/service/mission/MissionReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/mission/MissionReadServiceTest.java
@@ -8,6 +8,7 @@ import com.luckkids.domain.misson.MissionRepository;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
 import com.luckkids.domain.user.UserRepository;
+import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import java.util.List;
 import static com.luckkids.domain.misson.AlertStatus.CHECKED;
 import static com.luckkids.domain.misson.AlertStatus.UNCHECKED;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 class MissionReadServiceTest extends IntegrationTestSupport {
 
@@ -50,8 +52,11 @@ class MissionReadServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(List.of(user1, user2));
         missionRepository.saveAll(List.of(mission1_1, mission2_1, mission2_2));
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user1.getId()));
+
         // when
-        List<MissionResponse> missions = missionReadService.getMission(user1.getId());
+        List<MissionResponse> missions = missionReadService.getMission();
 
         // then
         assertThat(missions).extracting("missionDescription", "alertStatus", "alertTime")
@@ -74,8 +79,11 @@ class MissionReadServiceTest extends IntegrationTestSupport {
         userRepository.saveAll(List.of(user1, user2));
         missionRepository.saveAll(List.of(mission1_1, mission2_1, mission2_2));
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user2.getId()));
+
         // when
-        List<MissionResponse> missions = missionReadService.getMission(user2.getId());
+        List<MissionResponse> missions = missionReadService.getMission();
 
         // then
         assertThat(missions).extracting("missionDescription", "alertStatus", "alertTime")
@@ -135,4 +143,10 @@ class MissionReadServiceTest extends IntegrationTestSupport {
             .build();
     }
 
+    private UserInfo createUserInfo(int userId) {
+        return UserInfo.builder()
+            .userId(userId)
+            .email("")
+            .build();
+    }
 }

--- a/src/test/java/com/luckkids/api/service/mission/MissionServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/mission/MissionServiceTest.java
@@ -6,20 +6,19 @@ import com.luckkids.api.service.mission.request.MissionUpdateServiceRequest;
 import com.luckkids.api.service.mission.response.MissionResponse;
 import com.luckkids.domain.missionOutcome.MissionOutcome;
 import com.luckkids.domain.missionOutcome.MissionOutcomeRepository;
-import com.luckkids.domain.missionOutcome.MissionStatus;
 import com.luckkids.domain.misson.AlertStatus;
 import com.luckkids.domain.misson.Mission;
 import com.luckkids.domain.misson.MissionRepository;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
 import com.luckkids.domain.user.UserRepository;
+import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
@@ -28,6 +27,7 @@ import static com.luckkids.domain.missionOutcome.MissionStatus.FAILED;
 import static com.luckkids.domain.misson.AlertStatus.CHECKED;
 import static com.luckkids.domain.misson.AlertStatus.UNCHECKED;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 class MissionServiceTest extends IntegrationTestSupport {
 
@@ -61,6 +61,9 @@ class MissionServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
         missionRepository.save(mission);
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
         MissionCreateServiceRequest request = MissionCreateServiceRequest.builder()
             .missionDescription("책 읽기")
             .alertStatus(CHECKED)
@@ -68,7 +71,7 @@ class MissionServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        MissionResponse missionResponse = missionService.createMission(request, user.getId());
+        MissionResponse missionResponse = missionService.createMission(request);
 
         // then
         assertThat(missionResponse)
@@ -90,6 +93,9 @@ class MissionServiceTest extends IntegrationTestSupport {
         // given
         int userId = 1;
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(userId));
+
         MissionCreateServiceRequest request = MissionCreateServiceRequest.builder()
             .missionDescription("책 읽기")
             .alertStatus(CHECKED)
@@ -97,7 +103,7 @@ class MissionServiceTest extends IntegrationTestSupport {
             .build();
 
         // when // then
-        assertThatThrownBy(() -> missionService.createMission(request, userId))
+        assertThatThrownBy(() -> missionService.createMission(request))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("해당 유저는 없습니다. id = " + userId);
     }
@@ -113,6 +119,9 @@ class MissionServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
         missionRepository.save(mission);
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
         MissionCreateServiceRequest request = MissionCreateServiceRequest.builder()
             .missionDescription("책 읽기")
             .alertStatus(CHECKED)
@@ -120,7 +129,7 @@ class MissionServiceTest extends IntegrationTestSupport {
             .build();
 
         // when
-        MissionResponse createdMission = missionService.createMission(request, user.getId());
+        MissionResponse createdMission = missionService.createMission(request);
 
         // then
         List<MissionOutcome> missionOutcomes = missionOutcomeRepository.findAll();
@@ -238,11 +247,10 @@ class MissionServiceTest extends IntegrationTestSupport {
             .build();
     }
 
-    private MissionOutcome createMissionOutcome(Mission mission, LocalDate missionDate, MissionStatus missionStatus) {
-        return MissionOutcome.builder()
-            .mission(mission)
-            .missionDate(missionDate)
-            .missionStatus(missionStatus)
+    private UserInfo createUserInfo(int userId) {
+        return UserInfo.builder()
+            .userId(userId)
+            .email("")
             .build();
     }
 }

--- a/src/test/java/com/luckkids/api/service/missionOutcome/MissionOutcomeReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/missionOutcome/MissionOutcomeReadServiceTest.java
@@ -11,6 +11,7 @@ import com.luckkids.domain.misson.MissionRepository;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
 import com.luckkids.domain.user.UserRepository;
+import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static com.luckkids.domain.missionOutcome.MissionStatus.SUCCEED;
 import static com.luckkids.domain.misson.AlertStatus.UNCHECKED;
 import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 class MissionOutcomeReadServiceTest extends IntegrationTestSupport {
 
@@ -96,8 +98,11 @@ class MissionOutcomeReadServiceTest extends IntegrationTestSupport {
         missionRepository.saveAll(List.of(mission1, mission2));
         missionOutcomeRepository.saveAll(List.of(missionOutcome1, missionOutcome2));
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
         // when
-        List<MissionOutcomeResponse> missionOutcomeResponses = missionOutcomeReadService.getMissionDetailListForStatus(empty(), user.getId(), LocalDate.of(2023, 10, 25));
+        List<MissionOutcomeResponse> missionOutcomeResponses = missionOutcomeReadService.getMissionDetailListForStatus(empty(), LocalDate.of(2023, 10, 25));
 
         // then
         assertThat(missionOutcomeResponses).hasSize(2)
@@ -106,6 +111,30 @@ class MissionOutcomeReadServiceTest extends IntegrationTestSupport {
                 tuple("운동하기", LocalTime.of(19, 0), FAILED),
                 tuple("책읽기", LocalTime.of(20, 0), SUCCEED)
             );
+    }
+
+    @DisplayName("로그인된 유저아이디로 지금까지 성공한 미션의 개수를 조회한다.")
+    @Test
+    void countUserSuccessfulMissions() {
+        // given
+        User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO, "010-1111-1111");
+        Mission mission = createMission(user, "운동하기", UNCHECKED, LocalTime.of(19, 0));
+        MissionOutcome missionOutcome1 = createMissionOutcome(mission, LocalDate.of(2023, 10, 25), SUCCEED);
+        MissionOutcome missionOutcome2 = createMissionOutcome(mission, LocalDate.of(2023, 10, 26), SUCCEED);
+        MissionOutcome missionOutcome3 = createMissionOutcome(mission, LocalDate.of(2023, 10, 27), FAILED);
+
+        userRepository.save(user);
+        missionRepository.save(mission);
+        missionOutcomeRepository.saveAll(List.of(missionOutcome1, missionOutcome2, missionOutcome3));
+
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
+        // when
+        int count = missionOutcomeReadService.countUserSuccessfulMissions();
+
+        // then
+        assertThat(count).isEqualTo(2);
     }
 
     private User createUser(String email, String password, SnsType snsType, String phoneNumber) {
@@ -134,11 +163,10 @@ class MissionOutcomeReadServiceTest extends IntegrationTestSupport {
             .build();
     }
 
-    private MissionOutcomeResponse createMissionOutcomeResponse(String missionDescription, LocalTime alertTime, MissionStatus missionStatus) {
-        return MissionOutcomeResponse.builder()
-            .missionDescription(missionDescription)
-            .alertTime(alertTime)
-            .missionStatus(missionStatus)
+    private UserInfo createUserInfo(int userId) {
+        return UserInfo.builder()
+            .userId(userId)
+            .email("")
             .build();
     }
 }

--- a/src/test/java/com/luckkids/api/service/missionOutcome/MissionOutcomeServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/missionOutcome/MissionOutcomeServiceTest.java
@@ -10,6 +10,7 @@ import com.luckkids.domain.misson.MissionRepository;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
 import com.luckkids.domain.user.UserRepository;
+import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import static com.luckkids.domain.missionOutcome.MissionStatus.FAILED;
 import static com.luckkids.domain.missionOutcome.MissionStatus.SUCCEED;
 import static com.luckkids.domain.misson.AlertStatus.UNCHECKED;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 class MissionOutcomeServiceTest extends IntegrationTestSupport {
 
@@ -86,6 +88,9 @@ class MissionOutcomeServiceTest extends IntegrationTestSupport {
         missionRepository.save(mission);
         MissionOutcome savedMissionOutcome = missionOutcomeRepository.save(missionOutcome);
 
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
         // when
         missionOutcomeService.updateMissionOutcome(savedMissionOutcome.getId(), SUCCEED);
 
@@ -99,6 +104,32 @@ class MissionOutcomeServiceTest extends IntegrationTestSupport {
             );
     }
 
+    @DisplayName("업데이트할 id를 받아서 미션결과 상태를 업데이트하고 결과를 확인한다.")
+    @Test
+    void updateMissionOutcomeStatusByIdAndVerifyResult() {
+        // given
+        User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO, "010-1111-1111");
+        Mission mission = createMission(user, "운동하기", UNCHECKED, LocalTime.of(19, 0));
+        MissionOutcome missionOutcome1 = createMissionOutcome(mission, LocalDate.of(2023, 10, 26));
+        MissionOutcome missionOutcome2 = createMissionOutcome(mission, LocalDate.of(2023, 10, 27));
+        MissionOutcome missionOutcome3 = createMissionOutcome(mission, LocalDate.of(2023, 10, 28));
+
+        userRepository.save(user);
+        missionRepository.save(mission);
+        missionOutcomeRepository.saveAll(List.of(missionOutcome1, missionOutcome2, missionOutcome3));
+
+        given(securityService.getCurrentUserInfo())
+            .willReturn(createUserInfo(user.getId()));
+
+        // when
+        int count1 = missionOutcomeService.updateMissionOutcome(missionOutcome1.getId(), SUCCEED);
+        int count2 = missionOutcomeService.updateMissionOutcome(missionOutcome2.getId(), SUCCEED);
+
+        // then
+        assertThat(count1).isEqualTo(1);
+        assertThat(count2).isEqualTo(2);
+    }
+
     @DisplayName("업데이트할 id를 받아서 미션결과 상태를 업데이트 할 때 id가 없으면 예외가 발생한다.")
     @Test
     void updateMissionOutcomeWithException() {
@@ -109,8 +140,6 @@ class MissionOutcomeServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> missionOutcomeService.updateMissionOutcome(missionOutcomeId, SUCCEED))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("해당 미션결과는 없습니다. id = " + missionOutcomeId);
-
-
     }
 
     @DisplayName("삭제할 id를 받아서 미션결과를 삭제한다.")
@@ -157,6 +186,13 @@ class MissionOutcomeServiceTest extends IntegrationTestSupport {
             .mission(mission)
             .missionDate(missionDate)
             .missionStatus(FAILED)
+            .build();
+    }
+
+    private UserInfo createUserInfo(int userId) {
+        return UserInfo.builder()
+            .userId(userId)
+            .email("")
             .build();
     }
 }

--- a/src/test/java/com/luckkids/docs/mission/MissionControllerDocsTest.java
+++ b/src/test/java/com/luckkids/docs/mission/MissionControllerDocsTest.java
@@ -8,10 +8,8 @@ import com.luckkids.api.service.mission.MissionService;
 import com.luckkids.api.service.mission.request.MissionCreateServiceRequest;
 import com.luckkids.api.service.mission.request.MissionUpdateServiceRequest;
 import com.luckkids.api.service.mission.response.MissionResponse;
-import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.docs.RestDocsSupport;
 import com.luckkids.domain.misson.AlertStatus;
-import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -45,11 +43,10 @@ public class MissionControllerDocsTest extends RestDocsSupport {
 
     private final MissionService missionService = mock(MissionService.class);
     private final MissionReadService missionReadService = mock(MissionReadService.class);
-    private final SecurityService securityService = mock(SecurityService.class);
 
     @Override
     protected Object initController() {
-        return new MissionController(missionService, missionReadService, securityService);
+        return new MissionController(missionService, missionReadService);
     }
 
     @DisplayName("신규 미션을 등록하는 API")
@@ -63,10 +60,7 @@ public class MissionControllerDocsTest extends RestDocsSupport {
             .alertTime(LocalTime.of(18, 30))
             .build();
 
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
-
-        given(missionService.createMission(any(MissionCreateServiceRequest.class), anyInt()))
+        given(missionService.createMission(any(MissionCreateServiceRequest.class)))
             .willReturn(
                 createMissionResponse(1, "운동하기", CHECKED, LocalTime.of(18, 0))
             );
@@ -179,10 +173,7 @@ public class MissionControllerDocsTest extends RestDocsSupport {
     @WithMockUser(roles = "USER")
     void getMission() throws Exception {
         // given
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
-
-        given(missionReadService.getMission(anyInt()))
+        given(missionReadService.getMission())
             .willReturn(
                 List.of(
                     createMissionResponse(1, "운동하기", CHECKED, LocalTime.of(18, 0)),
@@ -258,13 +249,6 @@ public class MissionControllerDocsTest extends RestDocsSupport {
             .missionDescription(missionDescription)
             .alertStatus(alertStatus)
             .alertTime(alertTime)
-            .build();
-    }
-
-    private UserInfo createUserInfo() {
-        return UserInfo.builder()
-            .userId(1)
-            .email("")
             .build();
     }
 }

--- a/src/test/java/com/luckkids/docs/missionOutcome/MissionOutcomeControllerDocsTest.java
+++ b/src/test/java/com/luckkids/docs/missionOutcome/MissionOutcomeControllerDocsTest.java
@@ -5,10 +5,8 @@ import com.luckkids.api.controller.missionOutcome.request.MissionOutcomeUpdateRe
 import com.luckkids.api.service.missionOutcome.MissionOutcomeReadService;
 import com.luckkids.api.service.missionOutcome.MissionOutcomeService;
 import com.luckkids.api.service.missionOutcome.response.MissionOutcomeResponse;
-import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.docs.RestDocsSupport;
 import com.luckkids.domain.missionOutcome.MissionStatus;
-import com.luckkids.jwt.dto.UserInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -38,11 +36,10 @@ public class MissionOutcomeControllerDocsTest extends RestDocsSupport {
 
     private final MissionOutcomeService missionOutcomeService = mock(MissionOutcomeService.class);
     private final MissionOutcomeReadService missionOutcomeReadService = mock(MissionOutcomeReadService.class);
-    private final SecurityService securityService = mock(SecurityService.class);
 
     @Override
     protected Object initController() {
-        return new MissionOutcomeController(missionOutcomeService, missionOutcomeReadService, securityService);
+        return new MissionOutcomeController(missionOutcomeService, missionOutcomeReadService);
     }
 
     @DisplayName("등록되어있는 미션결과를 수정하는 API")
@@ -55,7 +52,7 @@ public class MissionOutcomeControllerDocsTest extends RestDocsSupport {
             .build();
 
         given(missionOutcomeService.updateMissionOutcome(1L, request.getMissionStatus()))
-            .willReturn(1L);
+            .willReturn(100);
 
         // when // then
         mockMvc.perform(
@@ -84,7 +81,7 @@ public class MissionOutcomeControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("message").type(JsonFieldType.STRING)
                         .description("메세지"),
                     fieldWithPath("data").type(JsonFieldType.NUMBER)
-                        .description("미션결과 id")
+                        .description("지금까지 성공한 미션의 개수")
                 )
             ));
     }
@@ -94,10 +91,7 @@ public class MissionOutcomeControllerDocsTest extends RestDocsSupport {
     @WithMockUser(roles = "USER")
     void getMissionDetailListForStatus() throws Exception {
         // given
-        given(securityService.getCurrentUserInfo())
-            .willReturn(createUserInfo());
-
-        given(missionOutcomeReadService.getMissionDetailListForStatus(empty(), 1, now()))
+        given(missionOutcomeReadService.getMissionDetailListForStatus(empty(), now()))
             .willReturn(
                 List.of(
                     createMissionOutcomeResponse(1L, "운동하기", LocalTime.of(19, 0), SUCCEED),
@@ -146,13 +140,6 @@ public class MissionOutcomeControllerDocsTest extends RestDocsSupport {
             .missionDescription(missionDescription)
             .alertTime(alertTime)
             .missionStatus(missionStatus)
-            .build();
-    }
-
-    private UserInfo createUserInfo() {
-        return UserInfo.builder()
-            .userId(1)
-            .email("")
             .build();
     }
 }


### PR DESCRIPTION
- 오늘의 미션을 성공했다고 클릭 했을 때 update하면서 지금까지 성공한 미션개수 보여주기
- https://github.com/luck-kids/luck-kids-server/issues/23 피드백에 따라 서비스에서 mocking하는걸로 수정
- https://github.com/luck-kids/luck-kids-server/issues/24 어떤 SELECT문이 좋을지? 질문드립니다 !