### PR TITLE
fix: 메시지내용이 아닌 Snstype을 내려주도록 변경

### DIFF
--- a/src/main/java/com/luckkids/domain/user/SnsType.java
+++ b/src/main/java/com/luckkids/domain/user/SnsType.java
@@ -22,7 +22,7 @@ public enum SnsType {
             .filter(type -> type.getText().equals(text))
             .findFirst();
         snsType.ifPresent(type -> {
-            throw new LuckKidsException(text+"로그인으로 이미 가입된 이메일입니다.");
+            throw new LuckKidsException(type.name());
         });
     }
 }


### PR DESCRIPTION
로그인이 다른 타입으로 이미 가입된 계정이 있으면 AS-IS로 내려줬는데
이번에 디자인변경에서 사용자가 다른 타입으로 가입된 계정이 있으면 따로 버튼으로 안내를 해주도록 추가되어서 메시지 보다는 TO-BE처럼 SnsType코드를 내려주는게 맞을 것 같아 변경했습니다.
![image](https://github.com/luck-kids/luck-kids-server/assets/68369248/7ff0b28e-0460-4963-ab02-2de059dce57c)

AS-IS
{
    "statusCode": 400,
    "httpStatus": "BAD_REQUEST",
    "message": "구글로그인으로 이미 가입된 이메일입니다. ",
    "data": null
}

TO-BE
{
    "statusCode": 400,
    "httpStatus": "BAD_REQUEST",
    "message": "GOOGLE",
    "data": null
}