### PR TITLE
feat: 친구코드로 조회시 요청자와 수신자의 친구관계 확인 프로세스 추가, 친구거절 API 추가

### DIFF
--- a/src/docs/asciidoc/api/friendCode/friendCode.adoc
+++ b/src/docs/asciidoc/api/friendCode/friendCode.adoc
@@ -35,3 +35,16 @@ include::{snippets}/create-friendcode/request-fields.adoc[]
 
 include::{snippets}/create-friendcode/http-response.adoc[]
 include::{snippets}/create-friendcode/response-fields.adoc[]
+
+[[refuse-friendCode]]
+=== 친구코드로 친구 닉네임 조회
+
+==== HTTP Request
+
+include::{snippets}/refuse-friendCode/http-request.adoc[]
+include::{snippets}/refuse-friendCode/path-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/refuse-friendCode/http-response.adoc[]
+include::{snippets}/refuse-friendCode/response-fields.adoc[]

--- a/src/main/java/com/luckkids/api/controller/friendCode/FriendCodeController.java
+++ b/src/main/java/com/luckkids/api/controller/friendCode/FriendCodeController.java
@@ -8,6 +8,7 @@ import com.luckkids.api.service.friendCode.request.FriendCodeNickNameServiceRequ
 import com.luckkids.api.service.friendCode.response.FriendCodeNickNameResponse;
 import com.luckkids.api.service.friendCode.response.FriendCreateResponse;
 import com.luckkids.api.service.friendCode.response.FriendInviteCodeResponse;
+import com.luckkids.api.service.friendCode.response.FriendRefuseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -36,5 +37,10 @@ public class FriendCodeController {
     @PostMapping("/create")
     public ApiResponse<FriendCreateResponse> create(@RequestBody @Valid FriendCreateRequest friendCreateRequest) {
         return ApiResponse.ok(friendCodeService.create(friendCreateRequest.toServiceRequest()));
+    }
+
+    @PostMapping("/{code}/refuse")
+    public ApiResponse<FriendRefuseResponse> refuseFriend(@PathVariable String code) {
+        return ApiResponse.ok(friendCodeService.refuseFriend(code));
     }
 }

--- a/src/main/java/com/luckkids/api/service/friend/FriendReadService.java
+++ b/src/main/java/com/luckkids/api/service/friend/FriendReadService.java
@@ -2,9 +2,12 @@ package com.luckkids.api.service.friend;
 
 import com.luckkids.api.page.request.PageInfoServiceRequest;
 import com.luckkids.api.page.response.PageCustom;
+import com.luckkids.api.service.friend.request.FriendStatusRequest;
 import com.luckkids.api.service.friend.response.FriendListResponse;
 import com.luckkids.api.service.security.SecurityService;
+import com.luckkids.domain.friend.Friend;
 import com.luckkids.domain.friend.FriendQueryRepository;
+import com.luckkids.domain.friend.FriendRepository;
 import com.luckkids.domain.friend.projection.FriendProfileDto;
 import com.luckkids.domain.user.UserQueryRepository;
 import com.luckkids.domain.user.projection.MyProfileDto;
@@ -13,6 +16,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,7 @@ public class FriendReadService {
     private final UserQueryRepository userQueryRepository;
 
     private final SecurityService securityService;
+    private final FriendRepository friendRepository;
 
     public FriendListResponse getFriendList(PageInfoServiceRequest pageRequest) {
         int userId = securityService.getCurrentLoginUserInfo().getUserId();
@@ -32,5 +38,10 @@ public class FriendReadService {
         Page<FriendProfileDto> friendPagingList = friendQueryRepository.getFriendList(userId, pageable);
 
         return FriendListResponse.of(myProfile, PageCustom.of(friendPagingList));
+    }
+
+    public boolean checkFriendStatus(FriendStatusRequest friendStatusRequest){
+        Optional<Friend> friend = friendRepository.findByRequesterIdAndReceiverId(friendStatusRequest.getRequestId(), friendStatusRequest.getReceiverId());
+        return friend.isPresent();
     }
 }

--- a/src/main/java/com/luckkids/api/service/friend/request/FriendStatusRequest.java
+++ b/src/main/java/com/luckkids/api/service/friend/request/FriendStatusRequest.java
@@ -1,0 +1,25 @@
+package com.luckkids.api.service.friend.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FriendStatusRequest {
+    private int requestId;
+    private int receiverId;
+
+    @Builder
+    public FriendStatusRequest(int requestId, int receiverId) {
+        this.requestId = requestId;
+        this.receiverId = receiverId;
+    }
+
+    public static FriendStatusRequest of(int requestId, int receiverId) {
+        return FriendStatusRequest.builder()
+                .requestId(requestId)
+                .receiverId(receiverId)
+                .build();
+    }
+}

--- a/src/main/java/com/luckkids/api/service/friendCode/FriendCodeReadService.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/FriendCodeReadService.java
@@ -2,10 +2,16 @@ package com.luckkids.api.service.friendCode;
 
 import com.luckkids.api.exception.ErrorCode;
 import com.luckkids.api.exception.LuckKidsException;
+import com.luckkids.api.service.friend.FriendReadService;
+import com.luckkids.api.service.friend.request.FriendStatusRequest;
 import com.luckkids.api.service.friendCode.request.FriendCodeNickNameServiceRequest;
 import com.luckkids.api.service.friendCode.response.FriendCodeNickNameResponse;
+import com.luckkids.api.service.security.SecurityService;
+import com.luckkids.api.service.user.UserReadService;
 import com.luckkids.domain.friendCode.FriendCode;
 import com.luckkids.domain.friendCode.FriendCodeRepository;
+import com.luckkids.domain.friendCode.FriendStatus;
+import com.luckkids.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +21,29 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class FriendCodeReadService {
     private final FriendCodeRepository friendCodeRepository;
+    private final SecurityService securityService;
+    private final FriendReadService friendReadService;
 
-    public FriendCode findByCode(String code){
+    public FriendCode findByCode(String code) {
         return friendCodeRepository.findByCode(code)
-            .orElseThrow(() -> new LuckKidsException(ErrorCode.FRIEND_CODE_UNKNOWN));
+                .orElseThrow(() -> new LuckKidsException(ErrorCode.FRIEND_CODE_UNKNOWN));
     }
 
-    public FriendCodeNickNameResponse findNickNameByCode(FriendCodeNickNameServiceRequest friendCreateServiceRequest){
+    public FriendCodeNickNameResponse findNickNameByCode(FriendCodeNickNameServiceRequest friendCreateServiceRequest) {
+        int receiverId = securityService.getCurrentLoginUserInfo().getUserId(); // 수신자 ID
         FriendCode friendCode = findByCode(friendCreateServiceRequest.getCode());
-        return FriendCodeNickNameResponse.of(friendCode.getUser().getNickname());
+        int requesterId = friendCode.getUser().getId(); // 요청자 ID
+
+        // 내가 보낸 초대인지 체크
+        if (requesterId == receiverId) {
+            return FriendCodeNickNameResponse.of(friendCode.getUser().getNickname(), FriendStatus.ME);
+        }
+
+        // 이미 친구인지 체크
+        boolean isAlreadyFriend = friendReadService.checkFriendStatus(FriendStatusRequest.of(requesterId, receiverId));
+        FriendStatus friendStatus = isAlreadyFriend ? FriendStatus.ALREADY : FriendStatus.FRIEND;
+
+        return FriendCodeNickNameResponse.of(friendCode.getUser().getNickname(), friendStatus);
     }
+
 }

--- a/src/main/java/com/luckkids/api/service/friendCode/FriendCodeService.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/FriendCodeService.java
@@ -3,6 +3,7 @@ package com.luckkids.api.service.friendCode;
 import com.luckkids.api.service.friendCode.request.FriendCreateServiceRequest;
 import com.luckkids.api.service.friendCode.response.FriendCreateResponse;
 import com.luckkids.api.service.friendCode.response.FriendInviteCodeResponse;
+import com.luckkids.api.service.friendCode.response.FriendRefuseResponse;
 import com.luckkids.api.service.push.PushService;
 import com.luckkids.api.service.push.request.SendPushAlertTypeServiceRequest;
 import com.luckkids.api.service.push.request.SendPushDataDto;
@@ -81,6 +82,12 @@ public class FriendCodeService {
         );
 
         return FriendCreateResponse.of(requestUser, receiveUser);
+    }
+
+    public FriendRefuseResponse refuseFriend(String code){
+        FriendCode friendCode = friendCodeReadService.findByCode(code);
+        friendCode.updateUseStatus();
+        return FriendRefuseResponse.of(code);
     }
 
     private String generateCode() {

--- a/src/main/java/com/luckkids/api/service/friendCode/request/FriendCodeNickNameServiceRequest.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/request/FriendCodeNickNameServiceRequest.java
@@ -1,5 +1,6 @@
 package com.luckkids.api.service.friendCode.request;
 
+import com.luckkids.api.service.friend.request.FriendStatusRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,4 +14,5 @@ public class FriendCodeNickNameServiceRequest {
     private FriendCodeNickNameServiceRequest(String code) {
         this.code = code;
     }
+
 }

--- a/src/main/java/com/luckkids/api/service/friendCode/response/FriendCodeNickNameResponse.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/response/FriendCodeNickNameResponse.java
@@ -1,5 +1,6 @@
 package com.luckkids.api.service.friendCode.response;
 
+import com.luckkids.domain.friendCode.FriendStatus;
 import com.luckkids.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,15 +11,18 @@ import lombok.NoArgsConstructor;
 public class FriendCodeNickNameResponse {
 
     private String nickName;
+    private FriendStatus friendStatus;
 
     @Builder
-    private FriendCodeNickNameResponse(String nickName) {
+    private FriendCodeNickNameResponse(String nickName, FriendStatus friendStatus) {
         this.nickName = nickName;
+        this.friendStatus = friendStatus;
     }
 
-    public static FriendCodeNickNameResponse of(String nickName){
+    public static FriendCodeNickNameResponse of(String nickName, FriendStatus friendStatus){
         return FriendCodeNickNameResponse.builder()
                 .nickName(nickName)
+                .friendStatus(friendStatus)
                 .build();
     }
 }

--- a/src/main/java/com/luckkids/api/service/friendCode/response/FriendCodeNickNameResponse.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/response/FriendCodeNickNameResponse.java
@@ -11,18 +11,18 @@ import lombok.NoArgsConstructor;
 public class FriendCodeNickNameResponse {
 
     private String nickName;
-    private FriendStatus friendStatus;
+    private FriendStatus status;
 
     @Builder
-    private FriendCodeNickNameResponse(String nickName, FriendStatus friendStatus) {
+    private FriendCodeNickNameResponse(String nickName, FriendStatus status) {
         this.nickName = nickName;
-        this.friendStatus = friendStatus;
+        this.status = status;
     }
 
-    public static FriendCodeNickNameResponse of(String nickName, FriendStatus friendStatus){
+    public static FriendCodeNickNameResponse of(String nickName, FriendStatus status){
         return FriendCodeNickNameResponse.builder()
                 .nickName(nickName)
-                .friendStatus(friendStatus)
+                .status(status)
                 .build();
     }
 }

--- a/src/main/java/com/luckkids/api/service/friendCode/response/FriendRefuseResponse.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/response/FriendRefuseResponse.java
@@ -1,0 +1,23 @@
+package com.luckkids.api.service.friendCode.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FriendRefuseResponse {
+
+    private String code;
+
+    @Builder
+    private FriendRefuseResponse(String code) {
+        this.code = code;
+    }
+
+    public static FriendRefuseResponse of(String code){
+        return FriendRefuseResponse.builder()
+                .code(code)
+                .build();
+    }
+}

--- a/src/main/java/com/luckkids/domain/friend/FriendRepository.java
+++ b/src/main/java/com/luckkids/domain/friend/FriendRepository.java
@@ -2,9 +2,13 @@ package com.luckkids.domain.friend;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     void deleteAllByReceiverId(int requestId);
 
     void deleteAllByRequesterId(int receiverId);
+
+    Optional<Friend> findByRequesterIdAndReceiverId(int requestId, int receiverId);
 }

--- a/src/main/java/com/luckkids/domain/friendCode/FriendStatus.java
+++ b/src/main/java/com/luckkids/domain/friendCode/FriendStatus.java
@@ -1,0 +1,14 @@
+package com.luckkids.domain.friendCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FriendStatus {
+    ME("내가 보낸 초대예요"),
+    ALREADY("이미 {nickname}님과 친구예요"),
+    FRIEND("{nickname}님이 친구초대를 보냈어요");
+
+    private final String text;
+}

--- a/src/test/java/com/luckkids/api/controller/friendCode/FriendCodeControllerTest.java
+++ b/src/test/java/com/luckkids/api/controller/friendCode/FriendCodeControllerTest.java
@@ -98,5 +98,22 @@ public class FriendCodeControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.message").value("친구코드는 필수입니다."))
             .andExpect(jsonPath("$.data").isEmpty());
     }
+
+    @DisplayName("친구요청을 거절한다.")
+    @Test
+    @WithMockUser("USER")
+    void refuseFriend() throws Exception {
+        // given
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/friendcode/{code}/refuse", "ASDWEDSS")
+                                .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
 }
 

--- a/src/test/java/com/luckkids/api/service/friend/FriendReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/friend/FriendReadServiceTest.java
@@ -1,6 +1,7 @@
 package com.luckkids.api.service.friend;
 
 import com.luckkids.IntegrationTestSupport;
+import com.luckkids.api.service.friend.request.FriendStatusRequest;
 import com.luckkids.domain.user.Role;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
@@ -170,6 +171,30 @@ class FriendReadServiceTest extends IntegrationTestSupport {
             .containsExactlyInAnyOrder(
                 1, 0, 0L
             );
+    }
+
+    @DisplayName("친구요청자와 수신자가 이미 친구인지 체크한다.")
+    @Test
+    void checkFriendStatus(){
+        // given
+        User user1 = createUser("test1@gmail.com", "test1234", "테스트1", "테스트1의 행운문구", 0);
+        User user2 = createUser("test2@gmail.com", "test1234", "테스트2", "테스트2의 행운문구", 0);
+        User user3 = createUser("test3@gmail.com", "test1234", "테스트3", "테스트3의 행운문구", 0);
+
+        userRepository.saveAll(List.of(user1, user2, user3));
+
+        Friend friend1 = createFriend(user1, user2);
+        friendRepository.save(friend1);
+
+        FriendStatusRequest friendStatusRequest = FriendStatusRequest.of(user1.getId(), user2.getId());
+        boolean check = friendReadService.checkFriendStatus(friendStatusRequest);
+
+        assertThat(check).isTrue();
+
+        friendStatusRequest = FriendStatusRequest.of(user1.getId(), user3.getId());
+        check = friendReadService.checkFriendStatus(friendStatusRequest);
+
+        assertThat(check).isFalse();
     }
 
     private User createUser(String email, String password, String nickname, String luckPhrase, int missionCount) {

--- a/src/test/java/com/luckkids/api/service/friendCode/FriendCodeReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/friendCode/FriendCodeReadServiceTest.java
@@ -80,7 +80,7 @@ public class FriendCodeReadServiceTest extends IntegrationTestSupport {
 
         FriendCodeNickNameResponse friendCodeNickNameResponse = friendCodeReadService.findNickNameByCode(friendCodeNickNameServiceRequest);
 
-        assertThat(friendCodeNickNameResponse).extracting("nickName", "friendStatus")
+        assertThat(friendCodeNickNameResponse).extracting("nickName", "status")
                 .contains("테스트2", FriendStatus.ALREADY);
     }
 

--- a/src/test/java/com/luckkids/api/service/friendCode/FriendCodeServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/friendCode/FriendCodeServiceTest.java
@@ -7,9 +7,11 @@ import com.luckkids.api.service.friendCode.response.FriendCreateResponse;
 import com.luckkids.api.service.friendCode.response.FriendInviteCodeResponse;
 import com.luckkids.api.service.push.PushService;
 import com.luckkids.api.service.security.SecurityService;
+import com.luckkids.domain.friend.Friend;
 import com.luckkids.domain.friend.FriendRepository;
 import com.luckkids.domain.friendCode.FriendCode;
 import com.luckkids.domain.friendCode.FriendCodeRepository;
+import com.luckkids.domain.friendCode.UseStatus;
 import com.luckkids.domain.user.Role;
 import com.luckkids.domain.user.SnsType;
 import com.luckkids.domain.user.User;
@@ -143,6 +145,23 @@ public class FriendCodeServiceTest extends IntegrationTestSupport {
             .hasMessage("이미 사용된 친구코드입니다.");
     }
 
+    @DisplayName("친구요청을 거절시 사용한 코드로 상태를 변경한다.")
+    @Test
+     void refuseFriendTest(){
+         // given
+         User user1 = userRepository.save(createUser(1));
+
+         userRepository.saveAll(List.of(user1));
+
+         FriendCode code = createFriendCode(user1);
+         friendCodeRepository.save(code);
+
+         friendCodeService.refuseFriend("ABCDEFGH");
+
+         FriendCode friendCode = friendCodeReadService.findByCode("ABCDEFGH");
+         assertThat(friendCode.getUseStatus()).isEqualTo(UseStatus.USED);
+     }
+
     private User createUser(int i) {
         return User.builder()
             .email("test" + i)
@@ -159,5 +178,13 @@ public class FriendCodeServiceTest extends IntegrationTestSupport {
         return LoginUserInfo.builder()
             .userId(userId)
             .build();
+    }
+
+    private FriendCode createFriendCode(User user){
+        return FriendCode.builder()
+                .user(user)
+                .code("ABCDEFGH")
+                .useStatus(UseStatus.UNUSED)
+                .build();
     }
 }

--- a/src/test/java/com/luckkids/docs/friendCode/FriendCodeControllerDocsTest.java
+++ b/src/test/java/com/luckkids/docs/friendCode/FriendCodeControllerDocsTest.java
@@ -85,7 +85,7 @@ public class FriendCodeControllerDocsTest extends RestDocsSupport {
         given(friendCodeReadService.findNickNameByCode(any(FriendCodeNickNameServiceRequest.class)))
                 .willReturn(FriendCodeNickNameResponse.builder()
                         .nickName("테스트 닉네임")
-                        .friendStatus(FriendStatus.FRIEND)
+                        .status(FriendStatus.FRIEND)
                         .build()
                 );
         // when // then

--- a/src/test/java/com/luckkids/docs/friendCode/FriendCodeControllerDocsTest.java
+++ b/src/test/java/com/luckkids/docs/friendCode/FriendCodeControllerDocsTest.java
@@ -9,11 +9,15 @@ import com.luckkids.api.service.friendCode.request.FriendCreateServiceRequest;
 import com.luckkids.api.service.friendCode.response.FriendCodeNickNameResponse;
 import com.luckkids.api.service.friendCode.response.FriendCreateResponse;
 import com.luckkids.api.service.friendCode.response.FriendInviteCodeResponse;
+import com.luckkids.api.service.friendCode.response.FriendRefuseResponse;
 import com.luckkids.docs.RestDocsSupport;
+import com.luckkids.domain.friendCode.FriendStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -81,6 +85,7 @@ public class FriendCodeControllerDocsTest extends RestDocsSupport {
         given(friendCodeReadService.findNickNameByCode(any(FriendCodeNickNameServiceRequest.class)))
                 .willReturn(FriendCodeNickNameResponse.builder()
                         .nickName("테스트 닉네임")
+                        .friendStatus(FriendStatus.FRIEND)
                         .build()
                 );
         // when // then
@@ -105,7 +110,46 @@ public class FriendCodeControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data").type(JsonFieldType.OBJECT)
                                         .description("응답 데이터"),
                                 fieldWithPath("data.nickName").type(JsonFieldType.STRING)
-                                        .description("요청자 닉네임")
+                                        .description("요청자 닉네임"),
+                                fieldWithPath("data.status").type(JsonFieldType.STRING)
+                                        .description("친구 상태값 가능한 값:" + Arrays.toString(FriendStatus.values()))
+                        )
+                ));
+    }
+
+    @DisplayName("친구요청 거절 API")
+    @Test
+    @WithMockUser(roles = "USER")
+    void refuseFriend() throws Exception {
+        // given
+        given(friendCodeService.refuseFriend(any(String.class)))
+                .willReturn(FriendRefuseResponse.builder()
+                        .code("ASDSDWEE")
+                        .build()
+                );
+        // when // then
+        mockMvc.perform(
+                        post("/api/v1/friendcode/{code}/refuse", "ASDSDWEE")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("refuse-friendCode",
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("code")
+                                        .description("친구 코드")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
+                                        .description("코드"),
+                                fieldWithPath("httpStatus").type(JsonFieldType.STRING)
+                                        .description("상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("메세지"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.code").type(JsonFieldType.STRING)
+                                        .description("거절한 친구코드")
                         )
                 ));
     }


### PR DESCRIPTION
1. 요청자와 수신자의 친구관계에 따라 보이는 팝업이 달라져서 /api/v1/friendcode/{code}/nickname API 에서 status값 추가해서 팝업분기 할수있도록 추가했습니다.
2. 수신자가 거절할수있는 버튼이 추가되서 버튼클릭시 호출하는 API 하나 개발했습니다. 거절하면 그냥 아무일도 없다고 하셔서 그냥 사용여부만 변경해주도록 했습니다.

지나님이 아직 slack에서 제가 제안한 1번 프로세스 확인안하시긴했는데 확인할때까지 또 기다렸다가 작업하면 제가 너무 늦어질거같아서 일단 개발했습니다..ㅋㅋ