### PR TITLE
Fix 친구요청을 받을시 알림히스토리 추가

### DIFF
--- a/src/main/java/com/luckkids/api/service/alertHistory/AlertHistoryReadService.java
+++ b/src/main/java/com/luckkids/api/service/alertHistory/AlertHistoryReadService.java
@@ -53,4 +53,9 @@ public class AlertHistoryReadService {
 		int userId = securityService.getCurrentLoginUserInfo().getUserId();
 		return alertHistoryQueryRepository.hasUncheckedAlerts(userId);
 	}
+
+	public boolean hasFriendCode(int userId, String friendCode){
+		return alertHistoryQueryRepository.hasFriendCode(userId, friendCode);
+	}
+
 }

--- a/src/main/java/com/luckkids/api/service/friendCode/request/FriendCodeNickNameServiceRequest.java
+++ b/src/main/java/com/luckkids/api/service/friendCode/request/FriendCodeNickNameServiceRequest.java
@@ -1,6 +1,11 @@
 package com.luckkids.api.service.friendCode.request;
 
+import com.luckkids.api.service.alertHistory.request.AlertHistoryServiceRequest;
+import com.luckkids.api.service.alertSetting.request.AlertSettingCreateServiceRequest;
 import com.luckkids.api.service.friend.request.FriendStatusRequest;
+import com.luckkids.domain.alertHistory.AlertDestinationType;
+import com.luckkids.domain.push.PushMessage;
+import com.luckkids.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +18,15 @@ public class FriendCodeNickNameServiceRequest {
     @Builder
     private FriendCodeNickNameServiceRequest(String code) {
         this.code = code;
+    }
+
+    public AlertHistoryServiceRequest toAlertHistoryServiceRequest(User user, String code) {
+        return AlertHistoryServiceRequest.builder()
+                .user(user)
+                .alertDescription(PushMessage.GARDEN.getText().replace("{nickName}", user.getNickname()))
+                .alertDestinationType(AlertDestinationType.FRIEND_CODE)
+                .alertDescription(code)
+                .build();
     }
 
 }

--- a/src/main/java/com/luckkids/domain/alertHistory/AlertDestinationType.java
+++ b/src/main/java/com/luckkids/domain/alertHistory/AlertDestinationType.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum AlertDestinationType {
 
 	FRIEND("친구 추가 알림"),
+	FRIEND_CODE("친구 추가요청 수신알림"),
 	MISSION("습관 추가 알림"),
 	WEBVIEW("URL이 필요한 알림");
 

--- a/src/main/java/com/luckkids/domain/alertHistory/AlertHistoryQueryRepository.java
+++ b/src/main/java/com/luckkids/domain/alertHistory/AlertHistoryQueryRepository.java
@@ -64,11 +64,34 @@ public class AlertHistoryQueryRepository {
 		).orElse(0L);
 	}
 
+	public boolean hasFriendCode(int userId, String friendCode) {
+		long count = ofNullable(
+				jpaQueryFactory
+						.select(alertHistory.count())
+						.from(alertHistory)
+						.where(
+								isUserIdEqualsTo(userId),
+								isAlertDestinationTypeEqualsTo(AlertDestinationType.FRIEND_CODE),
+								isAlertDestinationInfoEqualsTo(friendCode)
+						)
+						.fetchOne()
+		).orElse(0L);
+		return count > 0;
+	}
+
 	private BooleanExpression isUserIdEqualsTo(int userId) {
 		return alertHistory.user.id.eq(userId);
 	}
 
 	private BooleanExpression isStatusEqualsTo(AlertHistoryStatus status) {
 		return alertHistory.alertHistoryStatus.eq(status);
+	}
+
+	private BooleanExpression isAlertDestinationTypeEqualsTo(AlertDestinationType type) {
+		return alertHistory.alertDestinationType.eq(type);
+	}
+
+	private BooleanExpression isAlertDestinationInfoEqualsTo(String code) {
+		return alertHistory.alertDestinationInfo.eq(code);
 	}
 }

--- a/src/main/java/com/luckkids/domain/push/PushMessage.java
+++ b/src/main/java/com/luckkids/domain/push/PushMessage.java
@@ -13,7 +13,8 @@ public enum PushMessage {
     UPDATE("럭키즈의 새로워진 기능을 소개할게요!"),
     APP_UPDATE("럭키즈 새 버전 출시! 지금 구경갈래요?"),
     LUCK_CONTENTS("행운을 키우는 습관의 비하인드 스토리를 공개합니다."),
-    GARDEN("{nickName}님이 나를 가든에 추가했어요!");
+    GARDEN("{nickName}님이 나를 가든에 추가했어요!"),
+    FRIEND_CODE("{nickName}님이 친구 초대를 보냈어요!");
 
     private final String text;
 

--- a/src/test/java/com/luckkids/api/service/alertHistory/AlertHistoryReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/alertHistory/AlertHistoryReadServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.List;
 
+import com.luckkids.domain.alertHistory.AlertDestinationType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -144,6 +145,26 @@ class AlertHistoryReadServiceTest extends IntegrationTestSupport {
 		assertThat(result).isFalse();
 	}
 
+	@DisplayName("유저가 이미 요청받은 초대인지 확인한다.")
+	@Test
+	void hasFriendCodeAlert() {
+		// given
+		User user1 = createUser();
+		userRepository.save(user1);
+
+		Push push1 = createPush(user1);
+		pushRepository.save(push1);
+
+		AlertHistory alertHistory1 = createFriendCodeAlertHistory(user1, "test", CHECKED);
+		alertHistoryRepository.save(alertHistory1);
+
+		// when
+		boolean result = alertHistoryReadService.hasFriendCode(user1.getId(), "test");
+
+		// then
+		assertThat(result).isTrue();
+	}
+
 	private User createUser() {
 		return User.builder()
 			.email("test@email.com")
@@ -166,6 +187,15 @@ class AlertHistoryReadServiceTest extends IntegrationTestSupport {
 			.alertDescription(alertDescription)
 			.alertHistoryStatus(alertHistoryStatus)
 			.build();
+	}
+
+	private AlertHistory createFriendCodeAlertHistory(User user, String alertDescriptionInfo,AlertHistoryStatus alertHistoryStatus) {
+		return AlertHistory.builder()
+				.user(user)
+				.alertDestinationType(AlertDestinationType.FRIEND_CODE)
+				.alertDestinationInfo(alertDescriptionInfo)
+				.alertHistoryStatus(alertHistoryStatus)
+				.build();
 	}
 
 	private LoginUserInfo createLoginUserInfo(int userId) {

--- a/src/test/java/com/luckkids/api/service/friendCode/FriendCodeReadServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/friendCode/FriendCodeReadServiceTest.java
@@ -4,6 +4,7 @@ import com.luckkids.IntegrationTestSupport;
 import com.luckkids.api.service.friendCode.request.FriendCodeNickNameServiceRequest;
 import com.luckkids.api.service.friendCode.response.FriendCodeNickNameResponse;
 import com.luckkids.api.service.friendCode.response.FriendRefuseResponse;
+import com.luckkids.domain.alertHistory.AlertHistoryRepository;
 import com.luckkids.domain.friend.Friend;
 import com.luckkids.domain.friend.FriendRepository;
 import com.luckkids.domain.friendCode.FriendCode;
@@ -32,9 +33,12 @@ public class FriendCodeReadServiceTest extends IntegrationTestSupport {
     private FriendCodeReadService friendCodeReadService;
     @Autowired
     private FriendRepository friendRepository;
+    @Autowired
+    private AlertHistoryRepository alertHistoryRepository;
 
     @AfterEach
     void tearDown(){
+        alertHistoryRepository.deleteAllInBatch();
         friendCodeRepository.deleteAllInBatch();
         friendRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();

--- a/src/test/java/com/luckkids/api/service/friendCode/FriendCodeServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/friendCode/FriendCodeServiceTest.java
@@ -7,6 +7,7 @@ import com.luckkids.api.service.friendCode.response.FriendCreateResponse;
 import com.luckkids.api.service.friendCode.response.FriendInviteCodeResponse;
 import com.luckkids.api.service.push.PushService;
 import com.luckkids.api.service.security.SecurityService;
+import com.luckkids.domain.alertHistory.AlertHistoryRepository;
 import com.luckkids.domain.friend.Friend;
 import com.luckkids.domain.friend.FriendRepository;
 import com.luckkids.domain.friendCode.FriendCode;
@@ -46,9 +47,12 @@ public class FriendCodeServiceTest extends IntegrationTestSupport {
     private FriendCodeService friendCodeService;
     @Autowired
     private FriendCodeReadService friendCodeReadService;
+    @Autowired
+    private AlertHistoryRepository alertHistoryRepository;
 
     @AfterEach
     void tearDown() {
+        alertHistoryRepository.deleteAllInBatch();
         friendCodeRepository.deleteAllInBatch();
         friendRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();


### PR DESCRIPTION
친구요청을 받을 시 AlertHistory에 적재하는 프로세스가 있어서 추가했습니다.
친구요청을 받고 요청을 보낸 친구의 닉네임을 조회하는 API에서 AlertHistory에 해당 친구코드로 적재된 데이터가 없으면 insert하도록 했습니다!