### PR TITLE
fix: 회원가입, 초기세팅시 방어로직추가

### DIFF
--- a/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
+++ b/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
@@ -23,19 +23,23 @@ public class FirebaseService {
     private final ObjectMapper objectMapper;
 
     public void sendPushNotification(SendFirebaseServiceRequest sendPushServiceRequest) {
+        String pushToken = sendPushServiceRequest.getPush().getPushToken();
+        // PushToken이 없으면 메소드를 종료
+        if (pushToken == null || pushToken.isEmpty()) return;
+
         Message message = Message.builder()
-            .setApnsConfig(ApnsConfig.builder()
-                .setAps(Aps.builder()
-                    .putAllCustomData(ObjectToMap(sendPushServiceRequest.getSendFirebaseDataDto()))
-                    .setSound(sendPushServiceRequest.getSound())
-                    .setAlert(ApsAlert.builder()
-                        .setTitle(PushMessage.TITLE.getText())
-                        .setBody(sendPushServiceRequest.getBody())
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(Aps.builder()
+                                .putAllCustomData(ObjectToMap(sendPushServiceRequest.getSendFirebaseDataDto()))
+                                .setSound(sendPushServiceRequest.getSound())
+                                .setAlert(ApsAlert.builder()
+                                        .setTitle(PushMessage.TITLE.getText())
+                                        .setBody(sendPushServiceRequest.getBody())
+                                        .build())
+                                .build())
                         .build())
-                    .build())
-                .build())
-            .setToken(sendPushServiceRequest.getPush().getPushToken())
-            .build();
+                .setToken(pushToken)
+                .build();
 
         try {
             firebaseMessaging.send(message);

--- a/src/main/java/com/luckkids/api/service/initialSetting/InitialSettingService.java
+++ b/src/main/java/com/luckkids/api/service/initialSetting/InitialSettingService.java
@@ -31,6 +31,11 @@ public class InitialSettingService {
     private final SecurityService securityService;
 
     public InitialSettingResponse initialSetting(InitialSettingServiceRequest request) {
+        int userId = securityService.getCurrentLoginUserInfo().getUserId();
+        User user = userReadService.findByOne(userId);
+
+        user.checkSettingStatus();
+
         List<InitialSettingMissionResponse> initialSettingMissionResponses = request.getMissions().stream()
             .map(initialSettingMissionServiceRequest ->
                 missionService.createMission(initialSettingMissionServiceRequest.toMissionServiceRequest(request.getAlertSetting().getAlertStatus())).toInitialSettingResponse())
@@ -40,8 +45,6 @@ public class InitialSettingService {
 
         InitialSettingAlertResponse initialSettingAlertResponse = alertSettingService.createAlertSetting(request.getAlertSetting().toServiceRequest()).toInitialSettingResponse();
 
-        int userId = securityService.getCurrentLoginUserInfo().getUserId();
-        User user = userReadService.findByOne(userId);
         user.updateSettingStatus(COMPLETE);
 
         return InitialSettingResponse.of(initialSettingAlertResponse, initialSettingCharacterResponse, initialSettingMissionResponses);

--- a/src/main/java/com/luckkids/api/service/join/JoinReadService.java
+++ b/src/main/java/com/luckkids/api/service/join/JoinReadService.java
@@ -2,6 +2,7 @@ package com.luckkids.api.service.join;
 
 import com.luckkids.api.service.join.request.JoinCheckEmailServiceRequest;
 import com.luckkids.api.service.join.response.JoinCheckEmailResponse;
+import com.luckkids.domain.user.User;
 import com.luckkids.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,4 +23,6 @@ public class JoinReadService {
 
         return JoinCheckEmailResponse.of(email);
     }
+
+
 }

--- a/src/main/java/com/luckkids/api/service/join/JoinService.java
+++ b/src/main/java/com/luckkids/api/service/join/JoinService.java
@@ -2,6 +2,7 @@ package com.luckkids.api.service.join;
 
 import com.luckkids.api.exception.ErrorCode;
 import com.luckkids.api.exception.LuckKidsException;
+import com.luckkids.api.service.join.request.JoinCheckEmailServiceRequest;
 import com.luckkids.api.service.join.request.JoinServiceRequest;
 import com.luckkids.api.service.join.response.JoinResponse;
 import com.luckkids.domain.user.User;
@@ -21,18 +22,18 @@ public class JoinService {
     private final UserRepository userRepository;
     private final UserAgreementRepository userAgreementRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JoinReadService joinReadService;
 
     public JoinResponse joinUser(JoinServiceRequest joinServiceRequest) {
-        try {
-            User user = joinServiceRequest.toEntity();
-            user.updatePassword(bCryptPasswordEncoder.encode(user.getPassword()));
-            User savedUser = userRepository.save(user);
+        joinReadService.checkEmail(JoinCheckEmailServiceRequest.builder()
+                .email(joinServiceRequest.getEmail())
+                .build());
 
-            UserAgreement userAgreement = userAgreementRepository.save(joinServiceRequest.toUserAgreementEntity(savedUser));
+        User user = joinServiceRequest.toEntity();
+        user.updatePassword(bCryptPasswordEncoder.encode(user.getPassword()));
+        User savedUser = userRepository.save(user);
 
-            return JoinResponse.of(savedUser, userAgreement);
-        } catch (Exception e) {
-            throw new LuckKidsException(ErrorCode.USER_NORMAL);
-        }
+        UserAgreement userAgreement = userAgreementRepository.save(joinServiceRequest.toUserAgreementEntity(savedUser));
+        return JoinResponse.of(savedUser, userAgreement);
     }
 }

--- a/src/main/java/com/luckkids/domain/user/User.java
+++ b/src/main/java/com/luckkids/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.luckkids.domain.user;
 
+import com.luckkids.api.exception.LuckKidsException;
 import com.luckkids.domain.BaseTimeEntity;
 import com.luckkids.domain.push.Push;
 import com.luckkids.domain.refreshToken.RefreshToken;
@@ -136,5 +137,9 @@ public class User extends BaseTimeEntity {
 
     public void updateNickName(String nickName){
         this.nickname = nickName;
+    }
+
+    public void checkSettingStatus() {
+        if (this.settingStatus.equals(SettingStatus.COMPLETE)) throw new LuckKidsException("이미 초기세팅이 되어있는 사용자입니다.");
     }
 }


### PR DESCRIPTION
1. 회원가입시 중복으로 회원가입되지 않도록 예외 처리했습니다.
2. 초기세팅을 2번 호출하는일이 생겨 앞단에 이미 초기세팅이 되어있는경우는 예외 발생시키도록 했습니다