### PR TITLE
fix: 친구알림세팅 조건 추가

### DIFF
--- a/src/main/java/com/luckkids/domain/push/PushQueryRepository.java
+++ b/src/main/java/com/luckkids/domain/push/PushQueryRepository.java
@@ -34,6 +34,7 @@ public class PushQueryRepository {
             case LUCK -> alertSetting.luckMessage.eq(AlertStatus.CHECKED);
             case MISSION -> alertSetting.mission.eq(AlertStatus.CHECKED);
             case NOTICE -> alertSetting.notice.eq(AlertStatus.CHECKED);
+            case FRIEND -> alertSetting.friend.eq(AlertStatus.CHECKED);
             default -> throw new LuckKidsException(ErrorCode.LUCKKIDS_CHARACTER_UNKNOWN);
         };
     }


### PR DESCRIPTION
푸시포큰 조회시 친구알림 세팅 여부가 빠져있어서 추가했습니다