### PR TITLE
fix: findEmail API permitall

### DIFF
--- a/src/main/java/com/luckkids/config/SecurityConfig.java
+++ b/src/main/java/com/luckkids/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
 			new AntPathRequestMatcher("/api/v1/auth/**"),
 			new AntPathRequestMatcher("/api/v1/join/**"),
 			new AntPathRequestMatcher("/api/v1/mail/**"),
+			new AntPathRequestMatcher("/api/v1/user/findEmail"),
 			new AntPathRequestMatcher("/api/v1/confirmEmail/**"),
 			new AntPathRequestMatcher("/docs/**"),
 			new AntPathRequestMatcher("/css/**"),


### PR DESCRIPTION
findEmail이 누구나 호출할수있게 permitAll이 누락되어있어서 추가했스빈다