### PR TITLE
fix: 푸시발송 시 중복전송 방어로직

### DIFF
--- a/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
+++ b/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
@@ -8,6 +8,7 @@ import com.luckkids.api.service.firebase.request.SendFirebaseDataDto;
 import com.luckkids.api.service.firebase.request.SendFirebaseServiceRequest;
 import com.luckkids.domain.push.PushMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class FirebaseService {
 
     private final FirebaseMessaging firebaseMessaging;
@@ -45,7 +47,7 @@ public class FirebaseService {
             firebaseMessaging.send(message);
             alertHistoryService.createAlertHistory(AlertHistoryServiceRequest.of(sendPushServiceRequest));
         } catch (FirebaseMessagingException e){
-            throw new IllegalArgumentException(e.getMessage());
+            log.error("Token: "+ pushToken + "Error: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
+++ b/src/main/java/com/luckkids/api/service/firebase/FirebaseService.java
@@ -24,31 +24,33 @@ public class FirebaseService {
     private final AlertHistoryService alertHistoryService;
     private final ObjectMapper objectMapper;
 
-    public void sendPushNotification(SendFirebaseServiceRequest sendPushServiceRequest) {
-        String pushToken = sendPushServiceRequest.getPush().getPushToken();
-        // PushToken이 없으면 메소드를 종료
-        if (pushToken == null || pushToken.isEmpty()) return;
-
-        Message message = Message.builder()
-                .setApnsConfig(ApnsConfig.builder()
-                        .setAps(Aps.builder()
-                                .putAllCustomData(ObjectToMap(sendPushServiceRequest.getSendFirebaseDataDto()))
-                                .setSound(sendPushServiceRequest.getSound())
-                                .setAlert(ApsAlert.builder()
-                                        .setTitle(PushMessage.TITLE.getText())
-                                        .setBody(sendPushServiceRequest.getBody())
+    public void sendPushNotification(SendFirebaseServiceRequest sendPushServiceRequest, String pushToken) {
+        try {
+            // PushToken이 있으면 푸시전송
+            if (pushToken != null) {
+                Message message = Message.builder()
+                        .setApnsConfig(ApnsConfig.builder()
+                                .setAps(Aps.builder()
+                                        .putAllCustomData(ObjectToMap(sendPushServiceRequest.getSendFirebaseDataDto()))
+                                        .setSound(sendPushServiceRequest.getSound())
+                                        .setAlert(ApsAlert.builder()
+                                                .setTitle(PushMessage.TITLE.getText())
+                                                .setBody(sendPushServiceRequest.getBody())
+                                                .build())
                                         .build())
                                 .build())
-                        .build())
-                .setToken(pushToken)
-                .build();
+                        .setToken(pushToken)
+                        .build();
 
-        try {
-            firebaseMessaging.send(message);
-            alertHistoryService.createAlertHistory(AlertHistoryServiceRequest.of(sendPushServiceRequest));
+                firebaseMessaging.send(message);
+            }
         } catch (FirebaseMessagingException e){
             log.error("Token: "+ pushToken + "Error: " + e.getMessage());
+        } finally {
+            //히스토리는 무조건 쌓는걸로
+            alertHistoryService.createAlertHistory(AlertHistoryServiceRequest.of(sendPushServiceRequest));
         }
+
     }
 
     private Map<String, Object> ObjectToMap(SendFirebaseDataDto sendFirebaseDataDto){

--- a/src/main/java/com/luckkids/api/service/push/PushService.java
+++ b/src/main/java/com/luckkids/api/service/push/PushService.java
@@ -11,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,13 +24,19 @@ public class PushService {
     private final SecurityService securityService;
 
     public void sendPushAlertType(SendPushAlertTypeServiceRequest sendPushAlertTypeRequest){
+        Set<String> pushTokenSet = new HashSet<>();
         for(Push push : pushReadService.findAllByAlertType(sendPushAlertTypeRequest.getAlertType())){
-            firebaseService.sendPushNotification(sendPushAlertTypeRequest.toSendPushServiceRequest(push));
+            String pushToken = null;
+            if(!pushTokenSet.contains(push.getPushToken())) {
+                pushToken = push.getPushToken();
+            }
+            firebaseService.sendPushNotification(sendPushAlertTypeRequest.toSendPushServiceRequest(push), pushToken);
+            pushTokenSet.add(pushToken);
         }
     }
 
     public void sendPushToUser(SendPushServiceRequest sendPushServiceRequest){
-        firebaseService.sendPushNotification(sendPushServiceRequest.toSendPushServiceRequest());
+        firebaseService.sendPushNotification(sendPushServiceRequest.toSendPushServiceRequest(), sendPushServiceRequest.getPush().getPushToken());
     }
 
     public PushSoundChangeResponse updateSound(PushSoundChangeServiceRequest pushChangeServiceRequest){

--- a/src/test/java/com/luckkids/api/service/firebase/FirebaseServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/firebase/FirebaseServiceTest.java
@@ -47,7 +47,7 @@ public class FirebaseServiceTest extends IntegrationTestSupport {
             .sound("테스트 sound")
             .build();
 
-        firebaseService.sendPushNotification(sendPushServiceRequest);
+        firebaseService.sendPushNotification(sendPushServiceRequest, push.getPushToken());
     }
 
     private User createUser(String email, String password, String nickname, String luckPhrase, int missionCount) {


### PR DESCRIPTION
안녕하세요 건호님
그 전체 사용자에게 푸시를 발송할 시
만약 한 기기에서 3명의 사용자가 로그인을 하면 DB에 사용자별로 같은 PushToken이 저장되어서 전체발송을 하면 한기기에 3개의 동일한 알림이 가는 버그를 발견해서 Set을 사용해서 전송중복이 안되도록 방어로직을 추가했습니다