### PR TITLE
fix: 미션 활성화를 풀어도 삭제되지 않게 수정 !

### DIFF
--- a/src/main/java/com/luckkids/api/service/mission/MissionService.java
+++ b/src/main/java/com/luckkids/api/service/mission/MissionService.java
@@ -12,7 +12,6 @@ import com.luckkids.api.service.mission.response.MissionResponse;
 import com.luckkids.api.service.security.SecurityService;
 import com.luckkids.api.service.user.UserReadService;
 import com.luckkids.domain.misson.Mission;
-import com.luckkids.domain.misson.MissionActive;
 import com.luckkids.domain.misson.MissionRepository;
 import com.luckkids.domain.user.User;
 
@@ -43,7 +42,7 @@ public class MissionService {
 
 	public MissionResponse updateMission(int missionId, MissionUpdateServiceRequest request) {
 		Mission mission = missionReadService.findByOne(missionId);
-		MissionActive currentMissionActive = mission.getMissionActive();
+		// MissionActive currentMissionActive = mission.getMissionActive();
 
 		Mission updatedMission = mission.update(
 			request.getMissionType(),
@@ -53,7 +52,7 @@ public class MissionService {
 			request.getAlertTime()
 		);
 
-		missionEventService.handleMissionStateTransition(mission, currentMissionActive, request.getMissionActive());
+		// missionEventService.handleMissionStateTransition(mission, currentMissionActive, request.getMissionActive());
 
 		return MissionResponse.of(updatedMission);
 	}

--- a/src/main/java/com/luckkids/domain/push/PushMessage.java
+++ b/src/main/java/com/luckkids/domain/push/PushMessage.java
@@ -7,16 +7,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PushMessage {
 
-    TITLE("luckkids 럭키즈\uD83C\uDF40"),
-    DEFAULT_SOUND("noti_luckluck.wav"),
-    MISSION("새로운 습관이 추가되었어요!"),
-    UPDATE("럭키즈의 새로워진 기능을 소개할게요!"),
-    APP_UPDATE("럭키즈 새 버전 출시! 지금 구경갈래요?"),
-    LUCK_CONTENTS("행운을 키우는 습관의 비하인드 스토리를 공개합니다."),
-    GARDEN("{nickName}님이 나를 가든에 추가했어요!"),
-    FRIEND_CODE("{nickName}님이 친구 초대를 보냈어요!"),
-    WELCOME("환영해요 :) 럭키즈와 함께 행운을 키워가요!");
+	TITLE("luckkids 럭키즈\uD83C\uDF40"),
+	DEFAULT_SOUND("noti_drop.wav"),
+	MISSION("새로운 습관이 추가되었어요!"),
+	UPDATE("럭키즈의 새로워진 기능을 소개할게요!"),
+	APP_UPDATE("럭키즈 새 버전 출시! 지금 구경갈래요?"),
+	LUCK_CONTENTS("행운을 키우는 습관의 비하인드 스토리를 공개합니다."),
+	GARDEN("{nickName}님이 나를 가든에 추가했어요!"),
+	FRIEND_CODE("{nickName}님이 친구 초대를 보냈어요!"),
+	WELCOME("환영해요 :) 럭키즈와 함께 행운을 키워가요!");
 
-    private final String text;
+	private final String text;
 
 }

--- a/src/test/java/com/luckkids/api/service/mission/MissionServiceTest.java
+++ b/src/test/java/com/luckkids/api/service/mission/MissionServiceTest.java
@@ -216,86 +216,86 @@ class MissionServiceTest extends IntegrationTestSupport {
 			);
 	}
 
-	@DisplayName("수정할 미션 내용들을 받아 미션을 수정한다. (활성화 -> 비활성화 / missionOutcome 삭제 이벤트 발행)")
-	@Test
-	void updateMission_deleteEvent() {
-		// given
-		User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO);
-		userRepository.save(user);
+	/**
+	 @DisplayName("수정할 미션 내용들을 받아 미션을 수정한다. (활성화 -> 비활성화 / missionOutcome 삭제 이벤트 발행)")
+	 @Test void updateMission_deleteEvent() {
+	 // given
+	 User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO);
+	 userRepository.save(user);
 
-		Mission mission = createMission(user, HEALTH, "운동하기", TRUE, AlertStatus.CHECKED, LocalTime.of(0, 0));
-		Mission savedMission = missionRepository.save(mission);
+	 Mission mission = createMission(user, HEALTH, "운동하기", TRUE, AlertStatus.CHECKED, LocalTime.of(0, 0));
+	 Mission savedMission = missionRepository.save(mission);
 
-		MissionOutcome missionOutcome = createMissionOutcome(mission, LocalDate.now());
-		missionOutcomeRepository.save(missionOutcome);
+	 MissionOutcome missionOutcome = createMissionOutcome(mission, LocalDate.now());
+	 missionOutcomeRepository.save(missionOutcome);
 
-		int missionId = savedMission.getId();
+	 int missionId = savedMission.getId();
 
-		MissionUpdateServiceRequest request = MissionUpdateServiceRequest.builder()
-			.missionType(SELF_DEVELOPMENT)
-			.missionDescription("책 읽기")
-			.missionActive(FALSE)
-			.alertStatus(AlertStatus.CHECKED)
-			.alertTime(LocalTime.of(23, 30))
-			.build();
+	 MissionUpdateServiceRequest request = MissionUpdateServiceRequest.builder()
+	 .missionType(SELF_DEVELOPMENT)
+	 .missionDescription("책 읽기")
+	 .missionActive(FALSE)
+	 .alertStatus(AlertStatus.CHECKED)
+	 .alertTime(LocalTime.of(23, 30))
+	 .build();
 
-		// when
-		MissionResponse missionResponse = missionService.updateMission(missionId, request);
+	 // when
+	 MissionResponse missionResponse = missionService.updateMission(missionId, request);
 
-		// then
-		assertThat(missionResponse)
-			.extracting("missionType", "missionDescription", "alertStatus", "alertTime")
-			.contains(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30));
+	 // then
+	 assertThat(missionResponse)
+	 .extracting("missionType", "missionDescription", "alertStatus", "alertTime")
+	 .contains(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30));
 
-		List<Mission> missions = missionRepository.findAll();
-		assertThat(missions).hasSize(1)
-			.extracting("missionType", "missionDescription", "alertStatus", "alertTime")
-			.containsExactlyInAnyOrder(
-				tuple(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30))
-			);
+	 List<Mission> missions = missionRepository.findAll();
+	 assertThat(missions).hasSize(1)
+	 .extracting("missionType", "missionDescription", "alertStatus", "alertTime")
+	 .containsExactlyInAnyOrder(
+	 tuple(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30))
+	 );
 
-		List<MissionOutcome> missionOutcomes = missionOutcomeRepository.findAll();
-		assertThat(missionOutcomes).hasSize(0);
-	}
+	 List<MissionOutcome> missionOutcomes = missionOutcomeRepository.findAll();
+	 assertThat(missionOutcomes).hasSize(0);
+	 }
 
-	@DisplayName("수정할 미션 내용들을 받아 미션을 수정한다. (비활성화 -> 활성화 / missionOutcome 생성 이벤트 발행)")
-	@Test
-	void updateMission_createEvent() {
-		// given
-		User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO);
-		userRepository.save(user);
+	 @DisplayName("수정할 미션 내용들을 받아 미션을 수정한다. (비활성화 -> 활성화 / missionOutcome 생성 이벤트 발행)")
+	 @Test void updateMission_createEvent() {
+	 // given
+	 User user = createUser("user@daum.net", "user1234!", SnsType.KAKAO);
+	 userRepository.save(user);
 
-		Mission mission = createMission(user, HEALTH, "운동하기", FALSE, AlertStatus.CHECKED, LocalTime.of(0, 0));
-		Mission savedMission = missionRepository.save(mission);
+	 Mission mission = createMission(user, HEALTH, "운동하기", FALSE, AlertStatus.CHECKED, LocalTime.of(0, 0));
+	 Mission savedMission = missionRepository.save(mission);
 
-		int missionId = savedMission.getId();
+	 int missionId = savedMission.getId();
 
-		MissionUpdateServiceRequest request = MissionUpdateServiceRequest.builder()
-			.missionType(SELF_DEVELOPMENT)
-			.missionDescription("책 읽기")
-			.missionActive(TRUE)
-			.alertStatus(AlertStatus.CHECKED)
-			.alertTime(LocalTime.of(23, 30))
-			.build();
+	 MissionUpdateServiceRequest request = MissionUpdateServiceRequest.builder()
+	 .missionType(SELF_DEVELOPMENT)
+	 .missionDescription("책 읽기")
+	 .missionActive(TRUE)
+	 .alertStatus(AlertStatus.CHECKED)
+	 .alertTime(LocalTime.of(23, 30))
+	 .build();
 
-		// when
-		MissionResponse missionResponse = missionService.updateMission(missionId, request);
+	 // when
+	 MissionResponse missionResponse = missionService.updateMission(missionId, request);
 
-		// then
-		assertThat(missionResponse)
-			.extracting("missionType", "missionDescription", "alertStatus", "alertTime")
-			.contains(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30));
+	 // then
+	 assertThat(missionResponse)
+	 .extracting("missionType", "missionDescription", "alertStatus", "alertTime")
+	 .contains(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30));
 
-		List<Mission> missions = missionRepository.findAll();
-		assertThat(missions).hasSize(1)
-			.extracting("missionType", "missionDescription", "alertStatus", "alertTime")
-			.containsExactlyInAnyOrder(
-				tuple(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30))
-			);
+	 List<Mission> missions = missionRepository.findAll();
+	 assertThat(missions).hasSize(1)
+	 .extracting("missionType", "missionDescription", "alertStatus", "alertTime")
+	 .containsExactlyInAnyOrder(
+	 tuple(SELF_DEVELOPMENT, "책 읽기", AlertStatus.CHECKED, LocalTime.of(23, 30))
+	 );
 
-		List<MissionOutcome> missionOutcomes = missionOutcomeRepository.findAll();
-		assertThat(missionOutcomes).hasSize(1);
-	}
+	 List<MissionOutcome> missionOutcomes = missionOutcomeRepository.findAll();
+	 assertThat(missionOutcomes).hasSize(1);
+	 }
+	 **/
 
 	@DisplayName("미션 ID를 받아 미션을 삭제한다.(삭제일을 업데이트한다. Soft Delete)")
 	@Test


### PR DESCRIPTION
- read할 때 미션 active true인 것만 읽게되어서 굳이 삭제나 생성을 할 필요가 없음 ( 수정하는 이유는 미션 카운트를 유저 테이블에서 합쳐서 하고 있는데 이거 때문에 수가 맞지 않는 경우가 생김 )

- 아직 dev 서버가 없어서 혹시 몰라 주석 처리