### PR TITLE
fix: 탈퇴 버그 수정

### DIFF
--- a/src/main/java/com/luckkids/api/service/user/UserService.java
+++ b/src/main/java/com/luckkids/api/service/user/UserService.java
@@ -13,6 +13,7 @@ import com.luckkids.api.service.user.delete.UserAlertDeleteService;
 import com.luckkids.api.service.user.delete.UserCharacterDeleteService;
 import com.luckkids.api.service.user.delete.UserFriendCodeDeleteService;
 import com.luckkids.api.service.user.delete.UserFriendDeleteService;
+import com.luckkids.api.service.user.delete.UserLuckMessageHistoryDeleteService;
 import com.luckkids.api.service.user.delete.UserMissionDeleteService;
 import com.luckkids.api.service.user.delete.UserTokenDeleteService;
 import com.luckkids.api.service.user.request.UserUpdateLuckPhraseServiceRequest;
@@ -48,6 +49,7 @@ public class UserService {
 	private final UserFriendDeleteService userFriendDeleteService;
 	private final UserFriendCodeDeleteService userFriendCodeDeleteService;
 	private final UserAgreementDeleteService userAgreementDeleteService;
+	private final UserLuckMessageHistoryDeleteService userLuckMessageHistoryDeleteService;
 
 	public UserUpdatePasswordResponse updatePassword(
 		UserUpdatePasswordServiceRequest userUpdatePasswordServiceRequest) {
@@ -85,6 +87,7 @@ public class UserService {
 
 		userCharacterDeleteService.deleteAllByUserId(userId);
 		userAlertDeleteService.deleteAllByUserId(userId);
+		userLuckMessageHistoryDeleteService.deleteAllByUserId(userId);
 		userTokenDeleteService.deleteAllByUserId(userId);
 		userMissionDeleteService.deleteAllByUserId(userId);
 		userFriendDeleteService.deleteAllByUserId(userId);

--- a/src/main/java/com/luckkids/api/service/user/delete/UserLuckMessageHistoryDeleteService.java
+++ b/src/main/java/com/luckkids/api/service/user/delete/UserLuckMessageHistoryDeleteService.java
@@ -1,0 +1,19 @@
+package com.luckkids.api.service.user.delete;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.luckkids.domain.luckMessageHistory.LuckMessageHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserLuckMessageHistoryDeleteService {
+	private final LuckMessageHistoryRepository luckMessageHistoryRepository;
+
+	public void deleteAllByUserId(int userId) {
+		luckMessageHistoryRepository.deleteAllByUserId(userId);
+	}
+}

--- a/src/main/java/com/luckkids/api/service/user/delete/UserLuckMessageHistoryDeleteService.java
+++ b/src/main/java/com/luckkids/api/service/user/delete/UserLuckMessageHistoryDeleteService.java
@@ -14,6 +14,6 @@ public class UserLuckMessageHistoryDeleteService {
 	private final LuckMessageHistoryRepository luckMessageHistoryRepository;
 
 	public void deleteAllByUserId(int userId) {
-		luckMessageHistoryRepository.deleteAllByUserId(userId);
+		luckMessageHistoryRepository.deleteAllByPushUserId(userId);
 	}
 }

--- a/src/main/java/com/luckkids/domain/luckMessageHistory/LuckMessageHistoryRepository.java
+++ b/src/main/java/com/luckkids/domain/luckMessageHistory/LuckMessageHistoryRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LuckMessageHistoryRepository extends JpaRepository<LuckMessageHistory, Integer> {
 	Optional<LuckMessageHistory> findByPushDeviceIdAndPushUserId(String deviceId, int userId);
+
+	void deleteAllByUserId(int userId);
 }

--- a/src/main/java/com/luckkids/domain/luckMessageHistory/LuckMessageHistoryRepository.java
+++ b/src/main/java/com/luckkids/domain/luckMessageHistory/LuckMessageHistoryRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LuckMessageHistoryRepository extends JpaRepository<LuckMessageHistory, Integer> {
 	Optional<LuckMessageHistory> findByPushDeviceIdAndPushUserId(String deviceId, int userId);
 
-	void deleteAllByUserId(int userId);
+	void deleteAllByPushUserId(int userId);
 }


### PR DESCRIPTION
## 어떤 기능인가요?

> 행운의 한마디 이력 테이블이 추가되고 탈퇴테이블에 추가해주지 않아 에러가 발생했습니다.

## 작업 상세 내용

- [x] LuckMessageDeleteService 생성하여 푸시토큰 삭제전 행운의한마디 이력 삭제하도록 수정
